### PR TITLE
include browserify transforms as full dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![wercker status](https://app.wercker.com/status/bc221f27cbc9fc9a53a2157d8c20dd09/m/master "wercker status")](https://app.wercker.com/project/bykey/bc221f27cbc9fc9a53a2157d8c20dd09)
 
-**v1.0.1**
+**v1.0.2**
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/sprintly/sprintly-data.git"
   },
   "dependencies": {
-    "6to5": "^2.7.4",
+    "6to5": "^3.5.3",
     "6to5ify": "^3.1.0",
     "ampersand-dependency-mixin": "^0.2.3",
     "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -9,18 +9,18 @@
   },
   "dependencies": {
     "6to5": "^2.7.4",
+    "6to5ify": "^3.1.0",
     "ampersand-dependency-mixin": "^0.2.3",
     "async": "^0.9.0",
     "backbone-super-sync": "0.0.13",
     "backdash": "^1.1.2-2.4.1",
     "btoa": "^1.1.2",
+    "envify": "^3.0.0",
     "lodash": "^2.4.1",
     "q": "^1.0.1",
     "supermodel": "git://github.com/wookiehangover/supermodel.git"
   },
   "devDependencies": {
-    "envify": "^3.0.0",
-    "6to5ify": "^3.1.0",
     "browserify": "^8.0.0",
     "chai": "^1.9.1",
     "chai-as-promised": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sprintly-data",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "index.js",
   "browser": "sprintly-data.js",
   "repository": {


### PR DESCRIPTION
#### What does it do?

Fixes an issue caught by @BBonifield when trying to compile this in another project that didn't have 6to5ify

#### How should it be manually tested?

Include as a dependency in a project that doesn't also include 6to5ify.