### PR TITLE
fixing serialization for array values in API queries

### DIFF
--- a/lib/items/query-config.js
+++ b/lib/items/query-config.js
@@ -19,6 +19,11 @@ export default Model.extend({
     if (_.isObject(mergeWith)) {
       json = _.extend({}, json, mergeWith);
     }
+    _.each(json, function(value, key) {
+      if (_.isArray(value)) {
+        json[key] = value.join(',');
+      }
+    });
     return qs.stringify(json);
   }
 });

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ describe('slow', function() {
 describe('fast', function() {
   require('./products/product-test');
   require('./items/items-collection-test');
+  require('./items/items-query-config-test');
   require('./items/item-model-test');
   require('./items/comments-collection-test');
 });

--- a/test/items/items-query-config-test.js
+++ b/test/items/items-query-config-test.js
@@ -1,0 +1,27 @@
+import { assert } from "chai";
+import sinon from "sinon";
+import QueryConfig from "../../lib/items/query-config";
+
+
+describe('Items QueryConfig', function() {
+  before(function() {
+    this.sinon = sinon.sandbox.create();
+  });
+
+  beforeEach(function() {
+    this.config = new QueryConfig();
+  });
+
+  afterEach(function() {
+    this.sinon.restore();
+  });
+
+  describe('serialize', function() {
+    it('should present array fields as a comma delimited list', function() {
+      this.config.set({ type: ['story', 'defect' ]});
+      var querystring = this.config.serialize();
+      assert.ok(/type=story%2Cdefect/.test(querystring));
+    });
+  });
+});
+


### PR DESCRIPTION
#### What does this do?
The API only supports comma delimited lists for array values, which isn't the default output of node's built-in querystring serializer.

#### Where should the reviewer start?
This is a small change to handle any array-like value in `lib/items/query-config.js`

#### How can this be manually tested?
Created a client instance, a product, and an items collection. Modify the items collection's config object to use an array filter:
```javascript
itemsCollection.config.set({ type: ['story', 'defect' });
itemsCollection.fetch() // success
```