### PR TITLE
adding support for fetching a product’s related tags

### DIFF
--- a/lib/products/product.js
+++ b/lib/products/product.js
@@ -3,12 +3,17 @@ import { BASE_URL } from '../config';
 import Items from '../items';
 import Model from '../items/item';
 import People from './people';
+import Tags from './tags';
 import QueryConfig from '../items/query-config';
 
 export default Backbone.Model.extend({
 
   constructor: function(attrs) {
     this.members = new People(null, {
+      productId: attrs.id
+    });
+
+    this.tags = new Tags(null, {
       productId: attrs.id
     });
 

--- a/lib/products/tags.js
+++ b/lib/products/tags.js
@@ -1,0 +1,23 @@
+import _ from 'lodash';
+import { Collection } from '../support/backbone';
+import { BASE_URL } from '../config';
+import deps from 'ampersand-dependency-mixin';
+
+var TagsCollection = Collection.extend({
+  url: function() {
+    return `${BASE_URL}/products/${this.productId}/tags.json`;
+  },
+
+  dependencies: {
+    productId: 'Product ID'
+  },
+
+  initialize: function(models, options) {
+    this.attachDeps(options);
+  }
+});
+
+_.extend(TagsCollection.prototype, deps);
+
+export default TagsCollection;
+

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,8 @@ describe('slow', function() {
 
 describe('fast', function() {
   require('./products/product-test');
+  require('./products/tags-test');
+  require('./products/people-test');
   require('./items/items-collection-test');
   require('./items/items-query-config-test');
   require('./items/item-model-test');

--- a/test/products/people-test.js
+++ b/test/products/people-test.js
@@ -1,0 +1,19 @@
+import { assert } from "chai";
+import People from "../../lib/products/people";
+
+describe('People Collection', function() {
+  describe('constructor', function() {
+    it('requireds a product id', function() {
+      assert.throws(function() {
+        new People(null, {});
+      }, /Product ID/);
+    });
+  });
+
+  describe('url', function() {
+    it('should include the products id', function() {
+      var people = new People(null, { productId: 1 });
+      assert.include(people.url(), '/products/1/people.json');
+    });
+  });
+});

--- a/test/products/product-test.js
+++ b/test/products/product-test.js
@@ -5,6 +5,7 @@ import * as sprintly from "../..";
 import Items from "../../lib/items";
 import People from "../../lib/products/people";
 import Product from "../../lib/products/product";
+import Tags from "../../lib/products/tags";
 
 describe('Product Model', function() {
 
@@ -32,6 +33,10 @@ describe('Product Model', function() {
 
     it('creates a members collection', function() {
       assert.instanceOf(this.product.members, People);
+    });
+
+    it('creates a tags collection', function() {
+      assert.instanceOf(this.product.tags, Tags);
     });
 
     it('creates a unique Item supermodel', function() {

--- a/test/products/tags-test.js
+++ b/test/products/tags-test.js
@@ -1,0 +1,20 @@
+import { assert } from "chai";
+import Tags from "../../lib/products/tags";
+
+describe('Tags Collection', function() {
+
+  describe('constructor', function() {
+    it('requireds a product id', function() {
+      assert.throws(function() {
+        new Tags(null, {});
+      }, /Product ID/);
+    });
+  });
+
+  describe('url', function() {
+    it('should include the products id', function() {
+      var tags = new Tags(null, { productId: 1 });
+      assert.include(tags.url(), '/products/1/tags.json');
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?
The collection of tags for a given product can now be fetched:

```json
var product = client.products.get(1);
product.tags.fetch()
// => product.tags is populated with all the product's tags
```

### Where should the reviewer start?

`lib/product/tags.js`

This is nearly identical to how the people collection (`product.members`) is handled. Also added tests for the people collection because it's so similar.

### How does this make you feel?
![](http://media.giphy.com/media/10agyyi7VpV720/giphy.gif)

### Should this trigger a version bump?
- [x] Yes
  * [ ] MAJOR
  * [x] MINOR
  * [ ] PATCH
- [ ] No