### PR TITLE
item.toJSON should only send assigned_to as an id when saving to the API

### DIFF
--- a/lib/items/item.js
+++ b/lib/items/item.js
@@ -27,9 +27,17 @@ var Item = Supermodel.Model.extend({
     }
 
     if (options.save) {
-      if (_.isObject(attrs.assigned_to)) {
-        attrs.assigned_to = attrs.assigned_to.id;
+      _.each(['created_by', 'assigned_to'], function(key) {
+        if (_.isObject(attrs[key])) {
+          attrs[key] = attrs[key].id;
+        }
+      });
+
+      if (attrs.type === 'story') {
+        delete attrs.title;
       }
+
+      delete attrs.type;
     }
 
     return attrs;
@@ -46,11 +54,18 @@ var Item = Supermodel.Model.extend({
       (attrs = {})[key] = val;
     }
 
-    _.extend(options, {
-      save: true
-    });
+    options = options || {};
+    options.save = true;
 
-    return Supermodel.Model.prototype.save.call(this, attrs)
+    return Supermodel.Model.prototype.save.call(this, attrs, options)
+  },
+
+  sync: function(method, model, options={}) {
+    if (method === 'update') {
+      method = 'create';
+    }
+
+    return Supermodel.Model.prototype.sync.call(this, method, model, options);
   },
 
   validate: function(attrs) {
@@ -85,7 +100,7 @@ var Item = Supermodel.Model.extend({
 
     var optionalProps = {
       'description': _.isString,
-      'status': _.partial(_.contains, Object.keys(Item.ITEM_STATUSES))
+      'status': _.partial(_.contains, Object.keys(Item.ITEM_STATUSES)),
     };
 
     var invalidOptionalProps = _.reject(_.keys(optionalProps), function(name) {

--- a/lib/items/item.js
+++ b/lib/items/item.js
@@ -85,8 +85,7 @@ var Item = Supermodel.Model.extend({
 
     var optionalProps = {
       'description': _.isString,
-      'status': _.partial(_.contains, Object.keys(Item.ITEM_STATUSES)),
-      'assigned_to': _.isNumber
+      'status': _.partial(_.contains, Object.keys(Item.ITEM_STATUSES))
     };
 
     var invalidOptionalProps = _.reject(_.keys(optionalProps), function(name) {

--- a/lib/items/item.js
+++ b/lib/items/item.js
@@ -19,14 +19,38 @@ var Item = Supermodel.Model.extend({
     return url + '.json';
   },
 
-  toJSON: function() {
+  toJSON: function(options={}) {
     var attrs = Supermodel.Model.prototype.toJSON.call(this);
 
     if (_.isArray(attrs.tags)) {
       attrs.tags = attrs.tags.join(',');
     }
 
+    if (options.save) {
+      if (_.isObject(attrs.assigned_to)) {
+        attrs.assigned_to = attrs.assigned_to.id;
+      }
+    }
+
     return attrs;
+  },
+
+  save: function(key, val, options) {
+    var attrs;
+
+    // Handle both `"key", value` and `{key: value}` -style arguments.
+    if (key == null || typeof key === 'object') {
+      attrs = key;
+      options = val;
+    } else {
+      (attrs = {})[key] = val;
+    }
+
+    _.extend(options, {
+      save: true
+    });
+
+    return Supermodel.Model.prototype.save.call(this, attrs)
   },
 
   validate: function(attrs) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "async": "^0.9.0",
     "babel": "^4.6.6",
     "babelify": "^5.0.3",
-    "backbone-super-sync": "0.0.22",
+    "backbone-super-sync": "git://github.com/wookiehangover/backbone-super-sync",
     "backdash": "^1.1.2-2.4.1",
     "envify": "^3.0.0",
     "lodash": "^2.4.1",

--- a/test/items/item-model-test.js
+++ b/test/items/item-model-test.js
@@ -62,10 +62,23 @@ describe('Item Model', function() {
   });
 
   describe('toJSON', function() {
-    it('outputs just the item number for `assigned_to` when { save: true }', function() {
-      var item = Item.create({ number: 51, assigned_to: { id: 1 } });
-      var json = item.toJSON({ save: true });
-      assert.equal(json.assigned_to, 1);
+    context('{ save: true }', function() {
+      beforeEach(function() {
+        var item = Item.create({
+          number: 51,
+          type: 'story',
+          assigned_to: { id: 1 }
+        });
+        this.json = item.toJSON({ save: true });
+      });
+
+      it('outputs just the item number for `assigned_to`', function() {
+        assert.equal(this.json.assigned_to, 1);
+      });
+
+      it('removes item.type', function() {
+        assert.isUndefined(this.json.type);
+      });
     });
   });
 

--- a/test/items/item-model-test.js
+++ b/test/items/item-model-test.js
@@ -61,6 +61,14 @@ describe('Item Model', function() {
     });
   });
 
+  describe('toJSON', function() {
+    it('outputs just the item number for `assigned_to` when { save: true }', function() {
+      var item = Item.create({ number: 51, assigned_to: { id: 1 } });
+      var json = item.toJSON({ save: true });
+      assert.equal(json.assigned_to, 1);
+    });
+  });
+
   describe('validation', function() {
     it('enforces clientside validation errors', function() {
       var item = this.product.createItem({


### PR DESCRIPTION
### What does it do?

Makes the `assigned_to` field a number when saving the item with the server. Also looses the validation on that field to account for the fact that it's normally always an object until it's sent to the server.

### Where should the reviewer start?

The `toJSON` and `save` methods on the item model. Save needed some tinkering (namely argument juggling borrowed directly from backbone) to ensure that the `{ save: true }` option is passed through to toJSON.

### GIF?
![giphy](https://cloud.githubusercontent.com/assets/84644/6760727/d5857008-cf08-11e4-9dc4-cc1ae3302021.gif)

### Does this required a version bump?

- [x] Yes
  * [ ] MAJOR
  * [ ] MINOR
  * [x] PATCH
