### PR TITLE
add support for item resort API

### DIFF
--- a/lib/items/item.js
+++ b/lib/items/item.js
@@ -1,7 +1,10 @@
 import _ from 'lodash';
-import { Collection } from '../support/backbone';
+import { Collection, sync } from '../support/backbone';
 import Supermodel from 'supermodel';
 import Comments from './comments';
+import Superagent from 'superagent';
+import {BASE_URL} from '../config';
+import Q from 'q';
 
 var Item = Supermodel.Model.extend({
 
@@ -15,8 +18,38 @@ var Item = Supermodel.Model.extend({
   idAttribute: 'number',
 
   url: function() {
-    var url = Supermodel.Model.prototype.url.apply(this, arguments);
-    return url + '.json';
+    var productId = this.get('product').id;
+    var itemNumber = this.get('number');
+    return `${BASE_URL}/products/${productId}/items/${itemNumber}.json`;
+  },
+
+  resort: function(payload={}) {
+    if ( !(payload.before || payload.after) ) {
+      throw new Error('You must provide a value for before or after.');
+    }
+    var url = this.url().replace('.json', '/resort.json');
+    var item = this;
+    var req = Superagent.post(url)
+      .type('form')
+      .send(payload);
+
+    // decorate auth onto request
+    sync.editRequest(req);
+
+    return Q.Promise(function(resolve, reject) {
+      req.end(function(err, res) {
+        if (err) {
+          reject(err);
+        }
+
+        if (res.ok) {
+          item.set(res.body);
+          resolve();
+        } else {
+          reject();
+        }
+      });
+    });
   },
 
   toJSON: function(options={}) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "envify": "^3.0.0",
     "lodash": "^2.4.1",
     "q": "^1.1.2",
+    "superagent": "^1.1.0",
     "supermodel": "git://github.com/wookiehangover/supermodel.git"
   },
   "devDependencies": {

--- a/test/items/item-model-test.js
+++ b/test/items/item-model-test.js
@@ -104,6 +104,57 @@ describe('Item Model', function() {
     });
   });
 
+  describe('resort', function() {
+    beforeEach(function() {
+      this.server = sinon.fakeServer.create();
+      this.item = this.product.createItem({
+        number: 50,
+        product: {
+          id: 1
+        }
+      });
+      this.item.url = function() {
+        return '/products/1/items/50.json';
+      };
+    });
+
+    afterEach(function() {
+      this.server.restore();
+    });
+
+    it('returns a promise', function() {
+      this.server.respondWith(
+        'POST',
+        '/products/1/items/50/resort.json',
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          '{ "sort": 20000 }'
+        ]
+      );
+
+      var req = this.item.resort({ before: 2 });
+      this.server.respond();
+      return req;
+    });
+
+    it('rejects the promise if the server errors', function(done) {
+      this.server.respondWith(
+        'POST',
+        '/products/1/items/50.resort.json',
+        [500, {}, '']
+      );
+      this.item.resort({ before: 2 }).catch(function() {
+        done();
+      });
+      this.server.respond();
+    });
+
+    it('validates input', function() {
+      assert.throws(() => this.item.resort(), /must provide a value for before or after/);
+    });
+  });
+
 });
 
 


### PR DESCRIPTION
#### What does it do?

Creates a method on item models to use the newly-landed resort api https://github.com/sprintly/sprint.ly/pull/1851

#### Where should the reviewer start?

`lib/items/item.js`

#### How should it be manually tested?

Checkout the reordering branch of sprintly/5columns and use `npm link` to test that the code in this branch correctly calls the API, moves items around. 

#### GIF?
![6e9fabcf](https://cloud.githubusercontent.com/assets/84644/6952517/55dc110e-d877-11e4-82e6-68d5101c26a4.gif)

### Should this trigger a version bump?
- [x] Yes
  * [ ] MAJOR
  * [x] MINOR
  * [ ] PATCH
- [ ] No