### PR TITLE
Release 2.0.0 // formalize sub_items interface

### DIFF
--- a/lib/items/item.js
+++ b/lib/items/item.js
@@ -55,7 +55,7 @@ var Item = Supermodel.Model.extend({
     });
   },
 
-  toJSON: function(options={}) {
+  toJSON: function(options={ sub_items: true, parent: true }) {
     var attrs = Supermodel.Model.prototype.toJSON.call(this);
 
     if (_.isArray(attrs.tags)) {
@@ -63,7 +63,7 @@ var Item = Supermodel.Model.extend({
     }
 
     if (options.save) {
-      _.each(['created_by', 'assigned_to'], function(key) {
+      _.each(['created_by', 'assigned_to', 'accepted_by', 'parent'], function(key) {
         if (_.isObject(attrs[key])) {
           attrs[key] = attrs[key].id;
         }
@@ -75,6 +75,16 @@ var Item = Supermodel.Model.extend({
 
       if (attrs.number !== undefined) {
         delete attrs.type;
+      }
+    } else {
+      let sub_items = options.sub_items && this.sub_items && this.sub_items();
+      if (sub_items) {
+        attrs.sub_items = sub_items.toJSON({ parent: false });
+      }
+
+      let parent = options.parent && this.parent && this.parent();
+      if (parent) {
+        attrs.parent = parent.toJSON({ children: false });
       }
     }
 
@@ -178,15 +188,5 @@ Item.STAGES = {
   'Pending':  ['in-progress', 'completed'],
   'Done':     ['completed', 'accepted'],
 };
-
-Item.has().many('children', {
-  collection: Collection,
-  inverse: 'parent'
-});
-
-Item.has().one('parent', {
-  model: Item,
-  inverse: 'children'
-});
 
 export default Item;

--- a/lib/items/item.js
+++ b/lib/items/item.js
@@ -76,6 +76,11 @@ var Item = Supermodel.Model.extend({
       if (attrs.number !== undefined) {
         delete attrs.type;
       }
+
+      if (attrs.parent_id) {
+        attrs.parent = attrs.parent_id;
+        delete attrs.parent_id;
+      }
     } else {
       let sub_items = options.sub_items && this.sub_items && this.sub_items();
       if (sub_items) {

--- a/lib/products/product.js
+++ b/lib/products/product.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import Backbone from '../support/backbone';
 import { BASE_URL } from '../config';
 import Items from '../items';
@@ -20,6 +21,30 @@ export default Backbone.Model.extend({
     // Use Supermodel to create a trackable Item model for this collection
     var ItemModel = this.ItemModel = Model.extend({
       urlRoot: this.url(attrs.id).replace('.json', '/items')
+    });
+
+    let Children = Backbone.Collection.extend({
+      add(models, options={}) {
+        if (_.isArray(models)) {
+          models = _.map(models, function(model) {
+            return _.omit(model, 'parent');
+          });
+        }
+        return Backbone.Collection.prototype.add.call(this, models, options);
+      },
+      model(attrs, options) {
+        return ItemModel.create(attrs, options)
+      }
+    });
+
+    ItemModel.has().many('sub_items', {
+      collection: Children,
+      inverse: 'parent'
+    });
+
+    ItemModel.has().one('parent', {
+      model: ItemModel,
+      inverse: 'sub_items'
     });
 
     // Expose getter for the Supermodel backing collection

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sprintly-data",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "main": "index.js",
   "browser": "sprintly-data.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chai": "^2.1.0",
     "chai-as-promised": "^4.1.1",
     "es5-shim": "^4.1.1",
+    "exorcist": "^0.3.0",
     "gulp": "^3.8.7",
     "gulp-jshint": "^1.9.0",
     "gulp-mocha": "^2.0.0",
@@ -32,15 +33,15 @@
     "mocha": "^2.2.1",
     "sinon": "^1.10.3",
     "uglify-js": "^2.4.14",
-    "watchify": "^2.4.0"
+    "watchify": "^3.2.1"
   },
   "scripts": {
     "test": "mocha test",
     "test-browser": "gulp test",
     "build": "mkdir -p dist && browserify sprintly-data.js -o dist/sprintly.js -s sprintly",
-    "watch": "watchify sprintly-data.js -o dist/sprintly.js -s sprintly",
-    "build-test": "browserify test/browser/index.js -o test/browser/bundle.js -d",
-    "watch-test": "watchify test/browser/index.js -o test/browser/bundle.js -d -v",
+    "watch": "watchify sprintly-data.js -d -o './node_modules/.bin/exorcist dist/sprintly.js.map > dist/sprintly.js' -s sprintly",
+    "build-test": "browserify test/browser/index.js -d | ./node_modules/.bin/exorcist test/browser/bundle.js.map > test/browser/bundle.js",
+    "watch-test": "watchify test/browser/index.js -o './node_modules/.bin/exorcist test/browser/bundle.js.map > test/browser/bundle.js' -d -v",
     "minify": "uglifyjs dist/sprintly.js -c -m -o dist/sprintly.min.js ",
     "prepublish": "npm run build && npm run minify"
   },

--- a/test/items/item-model-test.js
+++ b/test/items/item-model-test.js
@@ -43,7 +43,7 @@ describe('Item Model', function() {
     });
 
     it('creates a parent item when updating a collection', function() {
-      var item = Item.create({ number: 51 });
+      var item = this.product.ItemModel.create({ number: 51 });
       var collection = this.product.createItemsCollection([], {});
 
       collection.add({ number: 51, parent: { number: 15 } });
@@ -87,6 +87,58 @@ describe('Item Model', function() {
         });
         var json = item.toJSON({ save: true });
         assert.equal(json.type, 'story');
+      });
+    });
+
+    context('sub_items', function() {
+      beforeEach(function() {
+        this.item = this.product.ItemModel.create({
+          number: 51,
+          type: 'story',
+          status: 'backlog'
+        });
+        this.subitem = this.product.ItemModel.create({
+          type: 'task', title: 'foo', status: 'backlog', number: 99, parent: 51
+        });
+      });
+
+      it('shows sub_items', function() {
+        let json = this.item.toJSON();
+        assert.deepEqual(json.sub_items[0], {
+          type: 'task', title: 'foo', status: 'backlog', number: 99, parent_id: 51
+        });
+      });
+
+      it('options { sub_items: false }', function() {
+        let json = this.item.toJSON({ sub_items: false });
+        assert.isUndefined(json.sub_items);
+      });
+    });
+
+    context('parent', function() {
+      beforeEach(function() {
+        this.product.ItemModel.create({
+          number: 51,
+          type: 'story',
+          status: 'backlog',
+        });
+        this.subitem = this.product.ItemModel.create({
+          type: 'task', title: 'foo', status: 'backlog', number: 99, parent: 51
+        });
+        this.json = this.subitem.toJSON();
+      });
+
+      it('shows a parent item', function() {
+        assert.deepEqual(this.json.parent, {
+          number: 51,
+          type: 'story',
+          status: 'backlog'
+        });
+      });
+
+      it('options { parent: false }', function() {
+        let json = this.subitem.toJSON({ parent: false });
+        assert.isUndefined(json.parent);
       });
     });
   });


### PR DESCRIPTION
#### What does it do?

Makes items and sub_items behavior behave consistently. See the 'background context' answer for more detail.

#### Where should the reviewer start?

`lib/products/product.js` – subitem relationships are made in the context of the product being created, so that make correct use of the Item Supermodel and prevent duplicates.

`lib/items/item.js` – the serialization logic here is needed for consistent results. There are also changes to make API requests persist correctly.

#### What's the relevant background context?

We previously had a 2 way mapping between "parent" items and their "children," but it was giving inconsistent results when used practically in an application. The only way to make sprintly-data collections aware of subitems was to make API requests with the `children` filter option set to true.

The main issue was that the number of subitems for a given parent potentially inconsistent if you're requesting just the Items for a specific status or a limited rage. If subitems existed but were outside your query, sprintly-data would only report on the subitems it knew about, with no way of determining if an given it was accurately displaying it's subitems.

This is related to the nested sub_items API change: https://github.com/sprintly/sprint.ly/pull/1904

