### PR TITLE
Add setting to allow external override of sprint.ly api URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 dist/
 test/browser/bundle.js
+test/browser/bundle.js.map

--- a/README.md
+++ b/README.md
@@ -195,3 +195,11 @@ Lint files
 ```bash
 $ gulp lint
 ```
+
+#### Internal Development Tools
+
+If you need to point to a non-production sprint.ly server you can set the following global variable before loading sprintly-data:
+
+```javascript
+var __sprintly_data_config = { BASE_URL: 'https://sprint.ly/api' };
+```

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,1 +1,3 @@
-export var BASE_URL = process.env.BASE_URL || 'https://sprint.ly/api';
+let config = typeof __sprintly_data_config !== 'undefined' ? __sprintly_data_config : {};
+
+export var BASE_URL = config.BASE_URL || process.env.BASE_URL || 'https://sprint.ly/api';


### PR DESCRIPTION
#### What's this PR do?

Adds support for a `__sprintly_data_config` variable for overriding config.
It currently support overriding the sprint.ly API url.
#### How should this be manually tested?

Best tested along side https://github.com/sprintly/sprintly-kanban/pull/75
#### Any background context you want to provide?

Added to support run-time configuration of sprintly-kanban.
#### What are the relevant tickets?

https://sprint.ly/product/31528/item/430
